### PR TITLE
Changed the parameter name dppath to dbpath

### DIFF
--- a/db/db.h
+++ b/db/db.h
@@ -9,7 +9,7 @@
 class DB {
    public:
     DB() = delete;
-    DB(const std::string &dppath);
+    DB(const std::string &dbpath);
     ~DB();
 
     static STATUS Create(const std::string &dbname);


### PR DESCRIPTION
Changed the parameter name in the DB class constructor from 'dppath' to 'dbpath'. This modification improves code readability and makes the purpose of the parameter more explicit, as 'dbpath' clearly indicates that it refers to the database path.
